### PR TITLE
fix(ContentReviewNotificationJob): Changed to use config system for job.

### DIFF
--- a/code/jobs/ContentReviewNotificationJob.php
+++ b/code/jobs/ContentReviewNotificationJob.php
@@ -90,11 +90,11 @@ class ContentReviewNotificationJob extends AbstractQueuedJob implements QueuedJo
         $nextRun = new ContentReviewNotificationJob();
 
         $nextRunTime = mktime(
-            self::$next_run_hour,
-            self::$next_run_minute,
+            Config::inst()->get(__CLASS__, 'next_run_hour'),
+            Config::inst()->get(__CLASS__, 'next_run_minute'),
             0,
             date("m"),
-            date("d") + self::$next_run_in_days,
+            date("d") + Config::inst()->get(__CLASS__, 'next_run_in_days'),
             date("Y")
         );
 


### PR DESCRIPTION
Changed to use ->config() system so that the $next_run_hour variable and others can be configured in YAML.