### PR TITLE
Avoid fatal errors when trying to edit in the CMS

### DIFF
--- a/code/extensions/SiteTreeContentReview.php
+++ b/code/extensions/SiteTreeContentReview.php
@@ -454,6 +454,10 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
 
         $options = $this->getOptions();
 
+        if (!$options || !$options->hasExtension($this->class)) {
+            return false;
+        }
+
         if ($options->OwnerGroups()->count() == 0 && $options->OwnerUsers()->count() == 0) {
             return false;
         }


### PR DESCRIPTION
If a page has it's `ContentReviewType` `Disabled` (either directly or on a parent via a `Inherit`) **AND ** has a `NextReviewDate` in the past, the page will cause a fatal error when attempting to load it for editing in the CMS. We can avoid this by checking if a pages Options are a boolean value (false for disabled) before trying to call methods on it. Addresses issue #55