### PR TITLE
FIX Import DateTimeField class for GridField column casting

### DIFF
--- a/src/Extensions/SiteTreeContentReview.php
+++ b/src/Extensions/SiteTreeContentReview.php
@@ -14,6 +14,7 @@ use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\DateField;
+use SilverStripe\Forms\DateTimeField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig;
@@ -359,7 +360,7 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
 
             // Cast the value to the users preferred date format
             $logColumns->setFieldCasting(array(
-                "Created" => "DateTimeField->value",
+                'Created' => DateTimeField::class . '->value',
             ));
 
             $logs = GridField::create("ROReviewNotes", "Review Notes", $this->owner->ReviewLogs(), $logConfig);


### PR DESCRIPTION
This is used when viewing the Content Review tab on a Page as a user that doesn't have permission to set or modify the content review settings.