### PR TITLE
v4: Add hook to updateSettingsFields so that devs can show/hide when desired

### DIFF
--- a/src/Extensions/SiteTreeContentReview.php
+++ b/src/Extensions/SiteTreeContentReview.php
@@ -328,6 +328,10 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
      */
     public function updateSettingsFields(FieldList $fields)
     {
+        if ($this->owner->hasMethod('displayContentReview') && !$this->owner->displayContentReview()) {
+            return;
+        }
+
         $module = ModuleLoader::getModule('silverstripe/contentreview');
         Requirements::javascript($module->getRelativeResourcePath('client/dist/js/contentreview.js'));
 


### PR DESCRIPTION
# Purpose

My project is using Fluent, which means that you can browse around the CMS in a bunch of different Locales. There are a lot of cases where the content displayed in the CMS for a page (in a particular Locale) is actually being inherited from a different Locale. In these cases, rather than display the Content Review, I would link them back to the correct Locale for the Review to take place.

If preferred, I can (of course) accomplish this without changes to the module, but I thought that this minor addition might be useful for other as well.