### PR TITLE
FIX Remove automatically scaffolded GridField for Site Tree Content Review in Member fields

### DIFF
--- a/src/Extensions/ContentReviewOwner.php
+++ b/src/Extensions/ContentReviewOwner.php
@@ -3,11 +3,9 @@
 namespace SilverStripe\ContentReview\Extensions;
 
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DataExtension;
 
-/**
- * Description of GroupContentReview.
- */
 class ContentReviewOwner extends DataExtension
 {
     /**
@@ -16,4 +14,10 @@ class ContentReviewOwner extends DataExtension
     private static $many_many = [
         "SiteTreeContentReview" => SiteTree::class,
     ];
+
+    public function updateCMSFields(FieldList $fields)
+    {
+        // Remove automatically scaffolded GridField in Member CMS fields
+        $fields->removeByName('SiteTreeContentReview');
+    }
 }


### PR DESCRIPTION
Resolves #81

Assumptions made:

* The automatically scaffolded GridField for "Site Tree Content Review" wasn't intended to be in Member CMS fields
* Removing it shouldn't affect the original A/C

If we want to keep it then it should be scaffolded explicity instead, and have a readonly GridFieldConfig