### PR TITLE
Constraint 4.0.x release line to SilverStripe 4.0 and 4.1, use contentreview 4.1 for SS 4.2+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
     ],
     "require": {
         "silverstripe/vendor-plugin": "^1",
-        "silverstripe/framework": "^4",
-        "silverstripe/cms": "^4",
-        "silverstripe/reports": "^4",
-        "silverstripe/siteconfig": "^4"
+        "silverstripe/framework": "~4.0.0 || ~4.1.0",
+        "silverstripe/cms": "~4.0.0 || ~4.1.0",
+        "silverstripe/reports": "~4.0.0 || ~4.1.0",
+        "silverstripe/siteconfig": "~4.0.0 || ~4.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
The contentreview 4.0.x release line uses a Javascript API that is only compatible with SS 4.0 and 4.1, so updating the constraints for this release line.

Users should use contentreview 4.1.x for SilverStripe 4.2.x or higher

Related: #85 and #86