### PR TITLE
FIX Updating test to not assert order of results 

### DIFF
--- a/tests/php/ContentReviewReportTest.php
+++ b/tests/php/ContentReviewReportTest.php
@@ -52,13 +52,17 @@ class ContentReviewReportTest extends FunctionalTest
             "ReviewDateBefore" => "2010-12-12",
         ]);
 
-        $this->assertEquals([
-            "Contact Us Child",
-            "Home",
-            "About Us",
-            "Staff",
-            "Contact Us",
-        ], $results->column("Title"));
+        $this->assertListContains([
+            ['Title' => 'Contact Us Child'],
+            ['Title' => 'Home'],
+            ['Title' => 'About Us'],
+            ['Title' => 'Staff'],
+            ['Title' => 'Contact Us'],
+        ], $results);
+        $this->assertListNotContains([
+            ['Title' => 'Page without review date'],
+            ['Title' => 'Page owned by group'],
+        ], $results);
 
         DBDatetime::set_mock_now("2010-02-13 00:00:00");
 


### PR DESCRIPTION
Recent changes in silverstripe/silverstripe-framework#8244 has changed the order that the ContentReviewReport shows pages that need review. This PR updates the test to be less assertive when it comes to the order - and instead just assert the correct contents of the result.

One day I'll understand `hub pull-request` 😂 

This should make the cwp-kitchen-sink build green again!