### PR TITLE
Fix - force people to use review bell

### DIFF
--- a/code/extensions/SiteTreeContentReview.php
+++ b/code/extensions/SiteTreeContentReview.php
@@ -383,7 +383,11 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
             ->addExtraClass('custom-setting')
             ->setDescription(_t("ContentReview.REVIEWFREQUENCYDESCRIPTION", "The review date will be set to this far in the future whenever the page is published"));
 
-        $notesField = GridField::create("ReviewNotes", "Review Notes", $this->owner->ReviewLogs(), GridFieldConfig_RecordEditor::create());
+		
+		$notesFieldConfig = GridFieldConfig_RecordEditor::create();
+		$notesFieldConfig->removeComponentsByType(new GridFieldAddNewButton());
+        $notesField = GridField::create("ReviewNotes", "Review Notes", $this->owner->ReviewLogs(), $notesFieldConfig)
+            ->setDescription(_t("ContentReview.REVIEWNOTESDESCRIPTION", "To create a new review note, use the bell icon below when the pages is due for a review"));
 
         $fields->addFieldsToTab("Root.ContentReview", array(
             new HeaderField(_t("ContentReview.REVIEWHEADER", "Content review"), 2),

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -27,6 +27,7 @@ en:
     REVIEWHEADER: 'Content review'
     REVIEWNOTES: 'Review notes'
     REVIEWSUCCESSFUL: 'Content reviewed successfully'
+    REVIEWNOTESDESCRIPTION: 'To create a new review note, use the bell icon below when the pages is due for a review'
     SAVE: Save
     SETTINGSFROM: 'Options are'
   ContentReviewEmails:


### PR DESCRIPTION
Fix for #94 

This fix disables you from creating a new review note from the gridfield, and reminds people to use the review feature which updates the review date