### PR TITLE
BUGFIX: Remove pages from content review email list, if a review log submitted after review date

### DIFF
--- a/src/Tasks/ContentReviewEmails.php
+++ b/src/Tasks/ContentReviewEmails.php
@@ -15,6 +15,7 @@ use SilverStripe\Security\Member;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
+use SilverStripe\ContentReview\Models\ContentReviewLog;
 
 /**
  * Daily task to send emails to the owners of content items when the review date rolls around.
@@ -54,6 +55,15 @@ class ContentReviewEmails extends BuildTask
 
         foreach ($pages as $page) {
             if (!$page->canBeReviewedBy()) {
+                continue;
+            }
+
+            // get most recent review log of current [age]
+            $contentReviewLog = $page->ReviewLogs()->sort('Created DESC')->first();
+
+            // check log date vs NextReviewDate. If someone has left a content review
+            // after the review date, then we don't need to notify anybody
+            if ($contentReviewLog && $contentReviewLog->Created >= $page->NextReviewDate) {
                 continue;
             }
 

--- a/src/Tasks/ContentReviewEmails.php
+++ b/src/Tasks/ContentReviewEmails.php
@@ -55,7 +55,6 @@ class ContentReviewEmails extends BuildTask
 
         foreach ($pages as $page) {
             if (!$page->canBeReviewedBy()) {
-                $page->advanceReviewDate();
                 continue;
             }
 
@@ -65,6 +64,7 @@ class ContentReviewEmails extends BuildTask
             // check log date vs NextReviewDate. If someone has left a content review
             // after the review date, then we don't need to notify anybody
             if ($contentReviewLog && $contentReviewLog->Created >= $page->NextReviewDate) {
+                $page->advanceReviewDate();
                 continue;
             }
 

--- a/src/Tasks/ContentReviewEmails.php
+++ b/src/Tasks/ContentReviewEmails.php
@@ -55,6 +55,7 @@ class ContentReviewEmails extends BuildTask
 
         foreach ($pages as $page) {
             if (!$page->canBeReviewedBy()) {
+                $page->advanceReviewDate();
                 continue;
             }
 


### PR DESCRIPTION
Currently, content owners of any pages past the review date will receive a email notification of their pages and there is no way of 'flagging' a page as reviewed to remove it from email lists. This fix is to remove pages from the emailing list to the content owner, if the most recent content review log submitted is past the set review date.