### PR TITLE
Fix - hide the reviewer ID from the CMS user

### DIFF
--- a/code/models/ContentReviewLog.php
+++ b/code/models/ContentReviewLog.php
@@ -40,4 +40,16 @@ class ContentReviewLog extends DataObject
     {
         return (bool) Member::currentUser();
     }
+
+
+    /**
+     * allow the user to edit the fields
+     * @return \FieldList
+     */
+    public function getCMSFields() {
+        $fields = FieldList::create();
+        $fields->push(TextareaField::create('Note'));
+        $fields->push(HiddenField::create('ReviewerID', 'ReviewerID', Member::currentUserID()));
+        return $fields;
+    }
 }

--- a/code/models/ContentReviewLog.php
+++ b/code/models/ContentReviewLog.php
@@ -47,8 +47,9 @@ class ContentReviewLog extends DataObject
      * @return \FieldList
      */
     public function getCMSFields() {
-        $fields = FieldList::create();
-        $fields->push(TextareaField::create('Note'));
+        $fields = parent::getCMSFields();
+        $fields->removeByName('ReviewerID');
+        $fields->removeByName('SiteTreeID');
         $fields->push(HiddenField::create('ReviewerID', 'ReviewerID', Member::currentUserID()));
         return $fields;
     }


### PR DESCRIPTION
Fix for #95 