### PR TITLE
BUGFIX: Error trying to OwnerGroups() method on boolean value

### DIFF
--- a/src/Reports/PagesWithoutReviewScheduleReport.php
+++ b/src/Reports/PagesWithoutReviewScheduleReport.php
@@ -154,7 +154,7 @@ class PagesWithoutReviewScheduleReport extends Report
 
         $options = $record->getOptions();
 
-        if ($options->OwnerGroups()->count() == 0 && $options->OwnerUsers()->count() == 0) {
+        if ($options && $options->OwnerGroups()->count() == 0 && $options->OwnerUsers()->count() == 0) {
             return false;
         }
 


### PR DESCRIPTION
This issue occurs when a page has "Inherit from parent page" for content
review option and a review date, and its parent has "Disable content
review" for content review option.