### PR TITLE
BUGFIX: Error trying to access OwnerGroups() method on boolean value

### DIFF
--- a/src/Reports/PagesDueForReviewReport.php
+++ b/src/Reports/PagesDueForReviewReport.php
@@ -217,9 +217,11 @@ class PagesDueForReviewReport extends Report
             $records = $records->filterByCallback(function ($page) use ($currentUser) {
                 $options = $page->getOptions();
 
-                foreach ($options->ContentReviewOwners() as $owner) {
-                    if ($currentUser->ID == $owner->ID) {
-                        return true;
+                if ($options) {
+                    foreach ($options->ContentReviewOwners() as $owner) {
+                        if ($currentUser->ID == $owner->ID) {
+                            return true;
+                        }
                     }
                 }
 

--- a/src/Tasks/ContentReviewEmails.php
+++ b/src/Tasks/ContentReviewEmails.php
@@ -70,12 +70,14 @@ class ContentReviewEmails extends BuildTask
 
             $option = $page->getOptions();
 
-            foreach ($option->ContentReviewOwners() as $owner) {
-                if (!isset($overduePages[$owner->ID])) {
-                    $overduePages[$owner->ID] = ArrayList::create();
-                }
+            if ($options) {
+                foreach ($option->ContentReviewOwners() as $owner) {
+                    if (!isset($overduePages[$owner->ID])) {
+                        $overduePages[$owner->ID] = ArrayList::create();
+                    }
 
-                $overduePages[$owner->ID]->push($page);
+                    $overduePages[$owner->ID]->push($page);
+                }
             }
         }
 

--- a/src/Tasks/ContentReviewEmails.php
+++ b/src/Tasks/ContentReviewEmails.php
@@ -68,10 +68,10 @@ class ContentReviewEmails extends BuildTask
                 continue;
             }
 
-            $option = $page->getOptions();
+            $options = $page->getOptions();
 
             if ($options) {
-                foreach ($option->ContentReviewOwners() as $owner) {
+                foreach ($options->ContentReviewOwners() as $owner) {
                     if (!isset($overduePages[$owner->ID])) {
                         $overduePages[$owner->ID] = ArrayList::create();
                     }


### PR DESCRIPTION
This fix is regarding a similar issue (https://github.com/silverstripe/silverstripe-contentreview/pull/101) 

We have found more areas where this behaviour might occur and have found it in two other places in PagesDueForReviewReport & ContentReviewEmails.

The fix mentioned in the link above does fix the main issue of not being able to access the 'Reports' model admin but fails to work when the 'Pages assigned to me' filter is triggered on the 'PagesDueForReview' report.

This PR here should fix that.