### PR TITLE
FIX Replace Convert JSON methods with json_* methods, deprecated from SilverStripe 4.4

### DIFF
--- a/src/Extensions/ContentReviewCMSExtension.php
+++ b/src/Extensions/ContentReviewCMSExtension.php
@@ -159,7 +159,7 @@ class ContentReviewCMSExtension extends LeftAndMainExtension
             $data = array_merge($data, $extraData);
         }
 
-        $response = HTTPResponse::create(Convert::raw2json($data));
+        $response = HTTPResponse::create(json_encode($data));
         $response->addHeader('Content-Type', 'application/json');
 
         return $response;


### PR DESCRIPTION
Issue: https://github.com/silverstripe/silverstripe-framework/issues/8424