### PR TITLE
FIX Allow users with the CMS_ACCESS_LeftAndMain permission to be added

### DIFF
--- a/src/Extensions/ContentReviewDefaultSettings.php
+++ b/src/Extensions/ContentReviewDefaultSettings.php
@@ -130,6 +130,7 @@ class ContentReviewDefaultSettings extends DataExtension
 
         $users = Permission::get_members_by_permission([
             'CMS_ACCESS_CMSMain',
+            'CMS_ACCESS_LeftAndMain',
             'ADMIN',
         ]);
 

--- a/src/Extensions/SiteTreeContentReview.php
+++ b/src/Extensions/SiteTreeContentReview.php
@@ -397,7 +397,7 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
             $options
         );
 
-        $users = Permission::get_members_by_permission(["CMS_ACCESS_CMSMain", "ADMIN"]);
+        $users = Permission::get_members_by_permission(['CMS_ACCESS_CMSMain', 'CMS_ACCESS_LeftAndMain', 'ADMIN']);
 
         $usersMap = $users->map("ID", "Title")->toArray();
 


### PR DESCRIPTION
Currently  members could not be assigned if they had the 'All sections' permission CMS_ACCESS_LeftAndMain ticked instead of the 'Pages section' ticked CMS_ACCESS_CMSMain

This is a bug fix rather than an functionality change, because `CMS_ACCESS_CMSMain` is a subset of `CMS_ACCESS_LeftAndMain`

There's a corresponding behat test added on 
- [ ] https://github.com/silverstripe/silverstripe-contentreview/pull/154
- [ ] https://github.com/silverstripe/silverstripe-contentreview/pull/172