### PR TITLE
ENH: Respect sort and limit arguments

### DIFF
--- a/src/Reports/PagesDueForReviewReport.php
+++ b/src/Reports/PagesDueForReviewReport.php
@@ -148,15 +148,25 @@ class PagesDueForReviewReport extends Report
 
     /**
      * @param array $params
+     * @param array|string|null $sort
+     * @param int|null $limit
      *
      * @return SS_List
      */
-    public function sourceRecords($params = [])
+    public function sourceRecords($params = [], $sort = null, $limit = null)
     {
         Versioned::set_stage(Versioned::DRAFT);
 
         $records = SiteTree::get();
         $compatibility = ContentReviewCompatability::start();
+
+        // Apply sort and limit if appropriate.
+        if ($sort !== null) {
+            $records = $records->sort($sort);
+        }
+        if ($limit !== null) {
+            $records = $records->limit($limit);
+        }
 
         if (empty($params['ReviewDateBefore']) && empty($params['ReviewDateAfter'])) {
             // If there's no review dates set, default to all pages due for review now

--- a/tests/php/ContentReviewReportTest.php
+++ b/tests/php/ContentReviewReportTest.php
@@ -87,11 +87,11 @@ class ContentReviewReportTest extends FunctionalTest
 
         $results = $report->sourceRecords();
 
-        $this->assertEquals([
-            "Home",
-            "About Us",
-            "Page without review date",
-            "Page owned by group",
-        ], $results->column("Title"));
+        $this->assertListEquals([
+            ['Title' => 'Home'],
+            ['Title' => 'About Us'],
+            ['Title' => 'Page without review date'],
+            ['Title' => 'Page owned by group'],
+        ], $results);
     }
 }


### PR DESCRIPTION
These parameters are defined in the PHPDocs for `Report` and are technically part of the method signature. They should be respected and in the case of the new default limit in silverstripe/silverstripe-reports#139 this could have performance ramifications for large datasets.

Note that `filterByCallback` applies the limit from the `DataList`