### PR TITLE
MNT Fix github action for deploying userdocs

### DIFF
--- a/.github/workflows/deploy-userhelp-docs.yml
+++ b/.github/workflows/deploy-userhelp-docs.yml
@@ -1,13 +1,14 @@
-name: Build Docs
+name: Deploy Userhelp Docs
 on:
   push:
     branches:
-      - 'master'
+      - '5'
+      - '4'
     paths:
       - 'docs/en/userguide/**'
 jobs:
-  build:
-    name: build-docs
+  deploy:
+    name: deploy-userhelp-docs
     runs-on: ubuntu-latest
     steps:
       - name: Run build hook


### PR DESCRIPTION
- Set the branches that activate the action to match the ones used by userhelp according to [the userhelp sources json](https://github.com/silverstripe/doc.silverstripe.org/blob/master/sources-user.js)
- More clearly and accurately identify the specific action (consistent with the naming used for related PRs) in case future actions are also added.

## Parent issue
- https://github.com/silverstripe/doc.silverstripe.org/issues/246