### PR TITLE
Allow to disable on pre-prod environments

### DIFF
--- a/docs/en/userguide/index.md
+++ b/docs/en/userguide/index.md
@@ -27,3 +27,12 @@ CMS users without the permission to change the content review schedule can still
 and previous reviews in the same view, but cannot change anything.
 
 ![Read only view of page content review settings](_images/content-review-settings-ro.png)
+
+## Disable for pre-prod environments
+
+The sending of emails can be disabled for pre-production environments. This may be needed if a production database is restored to a UAT environment.
+
+```
+SilverStripe\ContentReview\Tasks\ContentReviewEmails:
+  disablePreProd: true
+```

--- a/docs/en/userguide/index.md
+++ b/docs/en/userguide/index.md
@@ -30,9 +30,9 @@ and previous reviews in the same view, but cannot change anything.
 
 ## Disable for pre-prod environments
 
-The sending of emails can be disabled for pre-production environments. This may be needed if a production database is restored to a UAT environment.
+The sending of emails can be disabled. This feature may be needed for example, if a production database is restored to a UAT environment.
 
 ```
 SilverStripe\ContentReview\Tasks\ContentReviewEmails:
-  disablePreProd: true
+  send_emails: false
 ```

--- a/src/Tasks/ContentReviewEmails.php
+++ b/src/Tasks/ContentReviewEmails.php
@@ -4,7 +4,6 @@ namespace SilverStripe\ContentReview\Tasks;
 
 use Page;
 use SilverStripe\ContentReview\Compatibility\ContentReviewCompatability;
-use SilverStripe\Control\Director;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
@@ -22,15 +21,16 @@ use SilverStripe\View\SSViewer;
  */
 class ContentReviewEmails extends BuildTask
 {
-    private static $disablePreProd = false;
+    private static $send_emails = true;
+
     /**
      * @param HTTPRequest $request
      */
     public function run($request)
     {
-        // If the $disablePreProd static has been set to true, don't run the task
-        if (!Director::isLive() && $this->config()->get('disablePreProd')) {
-            echo 'The Content review task has been disabled for pre-prod environments';
+        // If the $send_emails static has been set to false, don't run the task
+        if (!$this->config()->get('send_emails')) {
+            echo 'The Content review task has been disabled';
             exit;
         }
 

--- a/src/Tasks/ContentReviewEmails.php
+++ b/src/Tasks/ContentReviewEmails.php
@@ -4,6 +4,7 @@ namespace SilverStripe\ContentReview\Tasks;
 
 use Page;
 use SilverStripe\ContentReview\Compatibility\ContentReviewCompatability;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\Email\Email;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
@@ -15,18 +16,24 @@ use SilverStripe\Security\Member;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\SSViewer;
-use SilverStripe\ContentReview\Models\ContentReviewLog;
 
 /**
  * Daily task to send emails to the owners of content items when the review date rolls around.
  */
 class ContentReviewEmails extends BuildTask
 {
+    private static $disablePreProd = false;
     /**
      * @param HTTPRequest $request
      */
     public function run($request)
     {
+        // If the $disablePreProd static has been set to true, don't run the task
+        if (!Director::isLive() && $this->config()->get('disablePreProd')) {
+            echo 'The Content review task has been disabled for pre-prod environments';
+            exit;
+        }
+
         $compatibility = ContentReviewCompatability::start();
 
         // First grab all the pages with a custom setting

--- a/src/Tasks/ContentReviewEmails.php
+++ b/src/Tasks/ContentReviewEmails.php
@@ -31,7 +31,7 @@ class ContentReviewEmails extends BuildTask
         // If the $send_emails static has been set to false, don't run the task
         if (!$this->config()->get('send_emails')) {
             echo 'The Content review task has been disabled';
-            exit;
+            return;
         }
 
         $compatibility = ContentReviewCompatability::start();


### PR DESCRIPTION
Restoring PROD data to UAT can result in the CMS user receiving emails from both environments. Allow to disable for pre-prod environments via config.