### PR TITLE
FIX Notification job marked as broken

### DIFF
--- a/tests/php/ContentReviewNotificationTest.php
+++ b/tests/php/ContentReviewNotificationTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\ContentReview\Tests;
 
 use Page;
+use ReflectionClass;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
 use SilverStripe\ContentReview\Extensions\ContentReviewCMSExtension;
@@ -130,6 +131,26 @@ class ContentReviewNotificationTest extends SapphireTest
         $this->assertNull($email);
 
         DBDatetime::clear_mock_now();
+    }
+
+    /**
+     * Test that provided email is valid
+     */
+    public function testIsValidEmail()
+    {
+        $class = new ReflectionClass(ContentReviewEmails::class);
+        $method = $class->getMethod('isValidEmail');
+        $method->setAccessible(true);
+
+        $member = $this->objFromFixture(Member::class, 'author');
+        $task = new ContentReviewEmails();
+
+        $this->assertTrue($method->invokeArgs($task, [$member->Email]));
+        $this->assertTrue($method->invokeArgs($task, ['correct.email@example.com']));
+
+        $this->assertFalse($method->invokeArgs($task, [null]));
+        $this->assertFalse($method->invokeArgs($task, ['broken.email']));
+        $this->assertFalse($method->invokeArgs($task, ['broken@email']));
     }
 
     /**


### PR DESCRIPTION
## Description
- Email validation for NULL, empty string and matching the correct email pattern.
- Method `run()` trows exception with list of invalid emails.

The job will be completed to the end, even if it comes across invalid emails, these emails will be skipped.
The email data will be placed in an array to provide a complete list of skipped (invalid) emails.
But the job will be marked as broken as it is more logical if not all emails were sent.

## Parent issue
- https://github.com/silverstripe/silverstripe-contentreview/issues/129
