### PR TITLE
DEP Bump minimum version of framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "silverstripe/vendor-plugin": "^1",
-        "silverstripe/framework": "^4.10",
+        "silverstripe/framework": "^4.11",
         "silverstripe/cms": "^4.2",
         "silverstripe/reports": "^4.2",
         "silverstripe/siteconfig": "^4.2"


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/284

Fixes an issue with egulias/email-validator on --prefer-lowest build

https://github.com/silverstripe/silverstripe-contentreview/actions/runs/9851668327/job/27198899798