### PR TITLE
FIX Update CMS fields now that they're being scaffolded

### DIFF
--- a/src/Extensions/SiteTreeContentReview.php
+++ b/src/Extensions/SiteTreeContentReview.php
@@ -93,6 +93,21 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
         "ContentReviewUsers" => Member::class,
     ];
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'ContentReviewType',
+            'ReviewPeriodDays',
+            'NextReviewDate',
+            'LastEditedByName',
+            'OwnerNames',
+        ],
+        'ignoreRelations' => [
+            'ReviewLogs',
+            'ContentReviewGroups',
+            'ContentReviewUsers',
+        ],
+    ];
+
     /**
      * @var array
      */


### PR DESCRIPTION
Relies on changes to `SiteTree` in https://github.com/silverstripe/silverstripe-cms/pull/2983


## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2767