### PR TITLE
FIX Handle when fallback email address is an array

### DIFF
--- a/src/Extensions/ContentReviewDefaultSettings.php
+++ b/src/Extensions/ContentReviewDefaultSettings.php
@@ -222,9 +222,14 @@ class ContentReviewDefaultSettings extends DataExtension
         if ($from) {
             return $from;
         }
-
         // Fall back to admin email
-        return Config::inst()->get(Email::class, 'admin_email');
+        $adminEmail = Config::inst()->get(Email::class, 'admin_email');
+        if (is_array($adminEmail)) {
+            // May be configured using an array ['admin-email@mysite.text' => 'Admin email label']
+            // https://docs.silverstripe.org/en/developer_guides/email/#administrator-emails
+            return array_values(array_keys($adminEmail))[0];
+        }
+        return $adminEmail;
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-admin/issues/1898

When setting SiteConfig to sudo mode, thus making the entire form readonly, you end up with the following template error:

`[Emergency] Uncaught TypeError: nl2br(): Argument #1 ($string) must be of type string, array given`

