### PR TITLE
FIX Advancing NextReviewDate no longer creates spurious draft versions

### DIFF
--- a/src/Extensions/SiteTreeContentReview.php
+++ b/src/Extensions/SiteTreeContentReview.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\ContentReview\Extensions;
 
-use Exception;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\ContentReview\Jobs\ContentReviewNotificationJob;
 use SilverStripe\ContentReview\Models\ContentReviewLog;
@@ -27,10 +26,11 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
-use SilverStripe\ORM\HasManyList;
-use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\FieldType\DBDate;
 use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\ManyManyList;
+use SilverStripe\ORM\Queries\SQLUpdate;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
@@ -38,6 +38,7 @@ use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use SilverStripe\Security\Security;
 use SilverStripe\SiteConfig\SiteConfig;
+use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Requirements;
 use Symbiote\QueuedJobs\DataObjects\QueuedJobDescriptor;
 use Symbiote\QueuedJobs\Services\QueuedJobService;
@@ -495,15 +496,59 @@ class SiteTreeContentReview extends DataExtension implements PermissionProvider
             );
 
             $this->owner->NextReviewDate = DBDate::create()->setValue($nextDateTimestamp)->Format(DBDate::ISO_DATE);
-            $this->owner->write();
+            $this->writeNextReviewDateToStages();
         }
 
         if ($options && $options->ReviewPeriodDays == 0) {
             $this->owner->NextReviewDate = null;
-            $this->owner->write();
+            $this->writeNextReviewDateToStages();
         }
 
         return (bool)$nextDateTimestamp;
+    }
+
+    /**
+     * Patch NextReviewDate directly on the draft table, and the live table if published,
+     * bypassing DataObject::write(). A normal write() bumps the Version column, which
+     * causes SiteTree::isModifiedOnDraft() to report the page as "Modified" purely
+     * because its review date advanced, even with no other changes.
+     * Genuine unpublished draft changes still show as "Modified", since they already move
+     * draft's Version ahead of live's independently of this method.
+     *
+     * @return void
+     */
+    private function writeNextReviewDateToStages()
+    {
+        // Fall back to a normal write for records that don't exist in the database yet -
+        // there's no draft row to patch, and this keeps creation behaviour unchanged.
+        if (!$this->owner->isInDB()) {
+            $this->owner->write();
+
+            return;
+        }
+
+        $schema = DataObject::getSchema();
+        $table  = $schema->tableForField(get_class($this->owner), 'NextReviewDate');
+
+        if (!$table) {
+            return;
+        }
+
+        $stages = [Versioned::DRAFT];
+
+        if ($this->owner->isPublished()) {
+            $stages[] = Versioned::LIVE;
+        }
+
+        foreach ($stages as $stage) {
+            $stageTable = $this->owner->stageTable($table, $stage);
+
+            SQLUpdate::create(
+                '"' . $stageTable . '"',
+                ['"NextReviewDate"' => $this->owner->NextReviewDate],
+                ['"ID"'             => $this->owner->ID]
+            )->execute();
+        }
     }
 
     /**

--- a/tests/php/SiteTreeContentReviewTest.php
+++ b/tests/php/SiteTreeContentReviewTest.php
@@ -401,4 +401,49 @@ class SiteTreeContentReviewTest extends ContentReviewBaseTest
 
         DBDatetime::clear_mock_now();
     }
+
+    public function testAdvanceReviewDateDoesNotPublishUnrelatedDraftChanges()
+    {
+        /** @var \Page|SiteTreeContentReview $page */
+        $page = new \Page();
+        $page->Title = 'Review sync test';
+        $page->Content = 'Original content';
+        $page->ContentReviewType = 'Custom';
+        $page->ReviewPeriodDays = 30;
+        $page->write();
+        $page->publishRecursive();
+
+        // Make an unrelated, unpublished draft edit
+        $page->Content = 'Draft-only edit';
+        $page->write();
+
+        $page->advanceReviewDate();
+
+        /** @var \Page $live */
+        $live = Versioned::get_by_stage(\Page::class, Versioned::LIVE)->byID($page->ID);
+        /** @var \Page $draft */
+        $draft = Versioned::get_by_stage(\Page::class, Versioned::DRAFT)->byID($page->ID);
+
+        $this->assertNotNull($draft->NextReviewDate);
+        $this->assertEquals($draft->NextReviewDate, $live->NextReviewDate);
+        $this->assertEquals('Original content', $live->Content);
+        $this->assertEquals('Draft-only edit', $draft->Content);
+    }
+
+    public function testAdvanceReviewDateDoesNotAffectUnpublishedPages()
+    {
+        /** @var \Page|SiteTreeContentReview $page */
+        $page = new \Page();
+        $page->Title = 'Unpublished review test';
+        $page->ContentReviewType = 'Custom';
+        $page->ReviewPeriodDays = 30;
+        $page->write();
+
+        $this->assertFalse($page->isPublished());
+
+        $page->advanceReviewDate();
+
+        $draft = Versioned::get_by_stage(\Page::class, Versioned::DRAFT)->byID($page->ID);
+        $this->assertNotNull($draft->NextReviewDate);
+    }
 }


### PR DESCRIPTION
## Description

When `advanceReviewDate()` is called during a content review, it was calling
`DataObject::write()` to persist the updated `NextReviewDate`. This increments
the `Version` column, which causes `SiteTree::isModifiedOnDraft()` to return
`true`, making the page appear as "Modified" in the CMS purely because its
review date advanced, not because any content changed.

This is a silent corruption of draft state that can cause editors to think
they have unsaved content changes when they don't.

## Fix

Replaces the `write()` call with direct SQL `UPDATE` queries via `SQLUpdate`,
patching `NextReviewDate` on both the draft and live versioned tables without
touching the `Version` column. Falls back to a normal `write()` for records
that haven't been persisted yet (no `ID`).

## Tests

Two new test cases added to `SiteTreeContentReviewTest`:

- `testAdvanceReviewDateDoesNotPublishUnrelatedDraftChanges`: verifies that
  advancing the review date doesn't interfere with existing unpublished draft edits
- `testAdvanceReviewDateDoesNotAffectUnpublishedPages`: confirms the method
  handles unpublished pages correctly

## Related

Fixes #134